### PR TITLE
Force install some dependency packages on AppVeyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,6 +13,11 @@ install:
 # Adapt as necessary starting from here
 
 build_script:
+  - travis-tool.sh install_r dplyr
+  - travis-tool.sh install_r broom
+  - travis-tool.sh install_r topicmodels
+  - travis-tool.sh install_r tidytext
+  - travis-tool.sh install_r unvotes
   - travis-tool.sh install_deps
 
 test_script:


### PR DESCRIPTION
I ran into this problem for builds on AppVeyor for tidytext, as discussed in https://github.com/krlmlr/r-appveyor/issues/69. The new version of devtools is having a problem with installing the dependencies of dependencies on Windows builds, it seems like. You can get the package to build by forcing it to install packages that have dependencies before `install_deps`. I think I got them all here by looking at `DESCRIPTION` and CRAN websites but it's possible there will be another one or two; I'll check if AppVeyor fails again.