### PR TITLE
Replace `data_frame()` with `tibble()`

### DIFF
--- a/R/pairwise_count.R
+++ b/R/pairwise_count.R
@@ -19,12 +19,12 @@
 #' @examples
 #'
 #' library(dplyr)
-#' dat <- data_frame(group = rep(1:5, each = 2),
-#'                   letter = c("a", "b",
-#'                              "a", "c",
-#'                              "a", "c",
-#'                              "b", "e",
-#'                              "b", "f"))
+#' dat <- tibble(group = rep(1:5, each = 2),
+#'               letter = c("a", "b",
+#'                          "a", "c",
+#'                          "a", "c",
+#'                          "b", "e",
+#'                          "b", "f"))
 #'
 #' # count the number of times two letters appear together
 #' pairwise_count(dat, letter, group)

--- a/R/pairwise_pmi.R
+++ b/R/pairwise_pmi.R
@@ -22,12 +22,12 @@
 #'
 #' library(dplyr)
 #'
-#' dat <- data_frame(group = rep(1:5, each = 2),
-#'                   letter = c("a", "b",
-#'                              "a", "c",
-#'                              "a", "c",
-#'                              "b", "e",
-#'                              "b", "f"))
+#' dat <- tibble(group = rep(1:5, each = 2),
+#'               letter = c("a", "b",
+#'                          "a", "c",
+#'                          "a", "c",
+#'                          "b", "e",
+#'                          "b", "f"))
 #'
 #' # how informative is each letter about each other letter
 #' pairwise_pmi(dat, letter, group)

--- a/man/pairwise_count.Rd
+++ b/man/pairwise_count.Rd
@@ -32,12 +32,12 @@ two words appear within documents).
 \examples{
 
 library(dplyr)
-dat <- data_frame(group = rep(1:5, each = 2),
-                  letter = c("a", "b",
-                             "a", "c",
-                             "a", "c",
-                             "b", "e",
-                             "b", "f"))
+dat <- tibble(group = rep(1:5, each = 2),
+              letter = c("a", "b",
+                         "a", "c",
+                         "a", "c",
+                         "b", "e",
+                         "b", "f"))
 
 # count the number of times two letters appear together
 pairwise_count(dat, letter, group)

--- a/man/pairwise_pmi.Rd
+++ b/man/pairwise_pmi.Rd
@@ -36,12 +36,12 @@ This is an example of the spread-operate-retidy pattern.
 
 library(dplyr)
 
-dat <- data_frame(group = rep(1:5, each = 2),
-                  letter = c("a", "b",
-                             "a", "c",
-                             "a", "c",
-                             "b", "e",
-                             "b", "f"))
+dat <- tibble(group = rep(1:5, each = 2),
+              letter = c("a", "b",
+                         "a", "c",
+                         "a", "c",
+                         "b", "e",
+                         "b", "f"))
 
 # how informative is each letter about each other letter
 pairwise_pmi(dat, letter, group)

--- a/tests/testthat/test-pairwise-cor.R
+++ b/tests/testthat/test-pairwise-cor.R
@@ -2,9 +2,9 @@ context("pairwise_cor")
 
 suppressPackageStartupMessages(library(dplyr))
 
-d <- data_frame(col = rep(c("a", "b", "c"), each = 3),
-                row = rep(c("d", "e", "f"), 3),
-                value = c(1, 2, 3, 6, 5, 4, 7, 9, 8))
+d <- tibble(col = rep(c("a", "b", "c"), each = 3),
+            row = rep(c("d", "e", "f"), 3),
+            value = c(1, 2, 3, 6, 5, 4, 7, 9, 8))
 
 test_that("pairwise_cor computes pairwise correlations", {
   ret <- d %>%

--- a/tests/testthat/test-pairwise-count.R
+++ b/tests/testthat/test-pairwise-count.R
@@ -5,10 +5,10 @@ context("pairwise_count")
 suppressPackageStartupMessages(library(dplyr))
 suppressPackageStartupMessages(library(tidytext))
 
-original <- data_frame(txt = c("I felt a funeral in my brain,",
-                               "And mourners, to and fro,",
-                               "Kept treading, treading, till it seemed",
-                               "That sense was breaking through.")) %>%
+original <- tibble(txt = c("I felt a funeral in my brain,",
+                           "And mourners, to and fro,",
+                           "Kept treading, treading, till it seemed",
+                           "That sense was breaking through.")) %>%
   mutate(line = row_number()) %>%
   unnest_tokens(char, txt, token = "characters")
 
@@ -56,9 +56,9 @@ test_that("pairing and counting works", {
 
 
 test_that("We can count with a weight column", {
-  d <- data_frame(col1 = c("a", "a", "a", "b", "b", "b"),
-                  col2 = c("x", "y", "z", "x", "x", "z"),
-                  weight = c(1, 1, 1, 5, 5, 5))
+  d <- tibble(col1 = c("a", "a", "a", "b", "b", "b"),
+              col2 = c("x", "y", "z", "x", "x", "z"),
+              weight = c(1, 1, 1, 5, 5, 5))
 
   ret1 <- pairwise_count(d, col2, col1)
   expect_equal(ret1$n[ret1$item1 == "z" & ret1$item2 == "y"], 1)
@@ -72,7 +72,7 @@ test_that("We can count with a weight column", {
 
 test_that("Counts co-occurences of words in Pride & Prejudice", {
   if (require("janeaustenr", quietly = TRUE)) {
-    words <- data_frame(text = prideprejudice) %>%
+    words <- tibble(text = prideprejudice) %>%
       mutate(line = row_number()) %>%
       unnest_tokens(word, text)
 

--- a/tests/testthat/test-pairwise-similarity.R
+++ b/tests/testthat/test-pairwise-similarity.R
@@ -2,9 +2,9 @@ context("pairwise_similarity")
 
 suppressPackageStartupMessages(library(dplyr))
 
-d <- data_frame(col = rep(c("a", "b", "c"), each = 3),
-                row = rep(c("d", "e", "f"), 3),
-                value = c(1, 2, 3, 6, 5, 4, 7, 9, 8))
+d <- tibble(col = rep(c("a", "b", "c"), each = 3),
+            row = rep(c("d", "e", "f"), 3),
+            value = c(1, 2, 3, 6, 5, 4, 7, 9, 8))
 
 cosine_similarity <- function(x, y) {
   sum(x * y) / (sqrt(sum(x^2)) * sqrt(sum(y^2)))

--- a/vignettes/united_nations.Rmd
+++ b/vignettes/united_nations.Rmd
@@ -102,7 +102,7 @@ library(igraph)
 cors_filtered <- cors %>%
   filter(correlation > .6)
 
-continents <- data_frame(country = unique(un_votes$country)) %>%
+continents <- tibble(country = unique(un_votes$country)) %>%
   filter(country %in% cors_filtered$item1 |
          country %in% cors_filtered$item2) %>%
   mutate(continent = countrycode(country, "country.name", "continent"))


### PR DESCRIPTION
The latest version of `dplyr` on CRAN `v0.8.3` (and `rlang` on CRAN `v0.4.0`) throws such a warning that is a depreciation notice of the use of `data_frame`.

```
Warning message:
`data_frame()` is deprecated, use `tibble()`.
```
