### PR TITLE
replace deprecated tbl_df with as_tibble

### DIFF
--- a/R/widely.R
+++ b/R/widely.R
@@ -109,7 +109,7 @@ widely_ <- function(.f,
 
     ret <- output %>%
       custom_melt() %>%
-      tbl_df()
+      as_tibble()
 
     if (sort) {
       ret <- arrange(ret, desc(value))


### PR DESCRIPTION
You mentioned during your [Tidy Tuesday live screencast on Analyzing cocktail recipes](https://www.youtube.com/watch?v=EC0SVkFB2OU) that you need to update widyr to use `as_tibble` instead of `tbl_df`. This pr does that. I have tested that this still works locally by running 

```
options(lifecycle_verbosity = "warning")
gapminder %>%
  pairwise_cor(country, year, lifeExp, upper = FALSE)
```

