### PR TITLE
update sparse matrix to `data.frame` coercion

### DIFF
--- a/R/widely.R
+++ b/R/widely.R
@@ -133,7 +133,30 @@ custom_melt <- function(m) {
   }
   # default to broom/tidytext's tidy
   ret <- suppressWarnings(purrr::possibly(broom::tidy, NULL)(m))
-
+  if (is.null(ret)) {
+    ret <- sparse_matrix_to_df(m)
+  }
   colnames(ret) <- c("item1", "item2", "value")
   ret
 }
+
+sparse_matrix_to_df <- function(x) {
+  s <- Matrix::summary(x)
+
+  row <- s$i
+  if (!is.null(rownames(x))) {
+    row <- rownames(x)[row]
+  }
+  col <- s$j
+  if (!is.null(colnames(x))) {
+    col <- colnames(x)[col]
+  }
+
+  ret <- data.frame(
+    row = row, column = col, value = s$x,
+    stringsAsFactors = FALSE
+  )
+
+  ret
+}
+

--- a/R/widely.R
+++ b/R/widely.R
@@ -126,16 +126,15 @@ widely_ <- function(.f,
 custom_melt <- function(m) {
   if (inherits(m, "data.frame")) {
     rlang::abort("Output is a data frame: don't know how to fix")
-  }
-  if (inherits(m, "matrix")) {
+  } else if (inherits(m, "matrix")) {
     ret <- reshape2::melt(m, varnames = c("item1", "item2"), as.is = TRUE)
     return(ret)
-  }
-  # default to broom/tidytext's tidy
-  ret <- suppressWarnings(purrr::possibly(broom::tidy, NULL)(m))
-  if (is.null(ret)) {
+  } else if (inherits(m, "Matrix")) {
     ret <- sparse_matrix_to_df(m)
+  } else {
+    ret <- tidy(m)
   }
+
   colnames(ret) <- c("item1", "item2", "value")
   ret
 }


### PR DESCRIPTION
Closes #40. This PR proposes inlining the deprecated tidier method as `sparse_matrix_to_df` and calling it if `broom::tidy()` fails.